### PR TITLE
Do not throw away all assistants with one deleted

### DIFF
--- a/lib/directory_diff/transform.rb
+++ b/lib/directory_diff/transform.rb
@@ -40,7 +40,10 @@ module DirectoryDiff
 
       if new_employee.nil?
         add_transform(:delete, old_employee)
-        assistant_owner[3] = nil
+        assistants_string = assistant_owner[3].to_s.split(",").reject do |assistant|
+                              assistant == email
+                            end.join(",")
+        assistant_owner[3] = assistants_string == "" ? nil : assistants_string
       else
         own_email = new_employee[1]
         assistant_emails = new_employee[3].to_s.split(",")

--- a/spec/directory_diff/transform_spec.rb
+++ b/spec/directory_diff/transform_spec.rb
@@ -426,6 +426,18 @@ describe DirectoryDiff::Transform do
           end
         end
 
+        context 'new directory has assistant emails, but no assistant records for one assistant' do
+          it 'returns an :insert op for employee and assistants, and sets the assistant that does exist' do
+            expect(transform.into([
+              ['Kamal Mahyuddin', 'kamal@envoy.com', '415-935-3143', 'adolfo@envoy.com,tristan@envoy.com'],
+              ['Adolfo Builes', 'adolfo@envoy.com', '415-935-3143', nil]
+            ])).to eq([
+              [:insert, 'Adolfo Builes', 'adolfo@envoy.com', '415-935-3143', nil],
+              [:insert, 'Kamal Mahyuddin', 'kamal@envoy.com', '415-935-3143', 'adolfo@envoy.com']
+            ])
+          end
+        end
+
         context 'new directory has circular reference' do
           it 'returns an :insert op for kamal, adolfo, and matthew' do
             expect(transform.into([
@@ -500,6 +512,18 @@ describe DirectoryDiff::Transform do
               ['Kamal Changed', 'kamal@envoy.com', '415-935-3143', 'adolfo@envoy.com,matthew@envoy.com']
             ])).to eq([
               [:update, 'Kamal Changed', 'kamal@envoy.com', '415-935-3143', nil]
+            ])
+          end
+        end
+
+        context 'new directory has assistant emails, but no assistant records for one assistant' do
+          it 'returns an :update op for employee and :insert for assistant, and sets the assistant that does exist' do
+            expect(transform.into([
+              ['Kamal Mahyuddin', 'kamal@envoy.com', '415-935-3143', 'adolfo@envoy.com,tristan@envoy.com'],
+              ['Adolfo Builes', 'adolfo@envoy.com', '415-935-3143', nil]
+            ])).to eq([
+              [:insert, 'Adolfo Builes', 'adolfo@envoy.com', '415-935-3143', nil],
+              [:update, 'Kamal Mahyuddin', 'kamal@envoy.com', '415-935-3143', 'adolfo@envoy.com']
             ])
           end
         end


### PR DESCRIPTION
Fixes a bug where all assistants would be removed if one of them was not in the new CSV