### PR TITLE
[Part 6] Introduce a temp table mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,23 @@
 language: ruby
-addons:
-  postgresql: 9.6
-services:
-  - postgresql 
-rvm:
-  - 2.4.4
-  - 2.5.1
+dist: xenial
+matrix:
+  include:
+    - name: "Run Ruby 2.4.4 against pg 9"
+      rvm: 2.4.4
+      addons:
+        postgresql: 9.6
+    - name: "Run Ruby 2.4.4 against pg 10"
+      rvm: 2.4.4
+      addons:
+        postgresql: 10
+    - name: "Run Ruby 2.5.1 against pg 9"
+      rvm: 2.5.1
+      addons:
+        postgresql: 9.6
+    - name: "Run Ruby 2.5.1 against pg 10"
+      rvm: 2.5.1
+      addons:
+        postgresql: 10
 before_install: gem install bundler -v 1.11.2
 script:
   - bundle exec rake db:create

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: ruby
+addons:
+  postgresql: 9.6
+services:
+  - postgresql 
 rvm:
-  - 2.3.0
-  - 2.3.1
+  - 2.4.4
+  - 2.5.1
 before_install: gem install bundler -v 1.11.2
+script:
+  - bundle exec rake db:create
+  - bundle exec rake spec

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in directory_diff.gemspec
 gemspec
+
+gem "activerecord_pg_stuff", "~> 0.0.1", path: "vendor/gems/activerecord_pg_stuff-0.0.1"

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,24 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "yaml"
+require "active_record"
 
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+namespace :db do
+  db_config = YAML::load(File.open("spec/support/database.yml"))
+  db_config_admin = db_config.merge({"database" => "postgres", "schema_search_path" => "public"})
+
+  desc "Create the database"
+  task :create do
+    begin
+      ActiveRecord::Base.establish_connection(db_config_admin)
+      ActiveRecord::Base.connection.create_database(db_config["database"])
+      puts "Database created."
+    rescue ActiveRecord::StatementInvalid
+      puts "Database already exist."
+    end
+  end
+end

--- a/directory_diff.gemspec
+++ b/directory_diff.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 5.1.4"
   spec.add_dependency "pg", "~> 1.1.3"
   spec.add_dependency "temping", "~> 3.10.0"
+  spec.add_dependency "activerecord_pg_stuff", "~> 0.0.1"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/directory_diff.gemspec
+++ b/directory_diff.gemspec
@@ -19,6 +19,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "activerecord", ">= 5.1.4"
+  spec.add_dependency "pg", "~> 1.1.3"
+  spec.add_dependency "temping", "~> 3.10.0"
+
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/directory_diff/transform.rb
+++ b/lib/directory_diff/transform.rb
@@ -1,4 +1,5 @@
 require_relative "transformer/in_memory"
+require_relative "transformer/temp_table"
 
 module DirectoryDiff
   class Transform
@@ -9,7 +10,21 @@ module DirectoryDiff
     end
 
     def into(new_directory, options = {})
-      Transformer::InMemory.new(current_directory).into(new_directory, options)
+      processor_class = processor_for(options[:processor])
+      processor_class.new(current_directory).into(new_directory, options)
+    end
+
+    private
+
+    def processor_for(processor)
+      case processor
+      when nil, :in_memory
+        Transformer::InMemory
+      when :temp_table
+        Transformer::TempTable
+      else
+        raise ArgumentError, "unsupported processor #{processor.inspect}"
+      end
     end
   end
 end

--- a/lib/directory_diff/transform.rb
+++ b/lib/directory_diff/transform.rb
@@ -1,124 +1,15 @@
+require_relative "transformer/in_memory"
+
 module DirectoryDiff
   class Transform
-    attr_reader :current_directory, :new_directory
-    attr_reader :transforms, :transforms_index
-    attr_reader :options
+    attr_reader :current_directory
 
     def initialize(current_directory)
       @current_directory = current_directory
-      @transforms = []
-      @transforms_index = {}
     end
 
-    def into(new_directory, options={})
-      raise ArgumentError unless new_directory.respond_to?(:each)
-      @new_directory = new_directory
-      @options = options || {}
-
-      new_employees.each do |email, employee|
-        process_employee(email, employee)
-      end
-
-      unseen_employees.each do |email, employee|
-        process_employee(email, employee)
-      end
-
-      transforms
-    end
-
-    protected
-
-    def process_employee(email, assistant_owner)
-      new_employee = find_new_employee(email)
-      old_employee = find_current_employee(email)
-
-      # cycle detection
-      if transforms_index.has_key?(email)
-        return
-      end
-      transforms_index[email] = nil
-
-      if new_employee.nil?
-        add_transform(:delete, old_employee)
-        assistants_string = assistant_owner[3].to_s.split(",").reject do |assistant|
-                              assistant == email
-                            end.join(",")
-        assistant_owner[3] = assistants_string == "" ? nil : assistants_string
-      else
-        own_email = new_employee[1]
-        assistant_emails = new_employee[3].to_s.split(",")
-        assistant_emails.delete(own_email)
-
-        assistant_emails.each do |assistant_email|
-          process_employee(assistant_email, new_employee)
-        end
-
-        # assistant_emails may be nil. we only use the csv to *set*
-        # assistants. if it was nil, we backfill from current employee so that
-        # the new record appears to be the same as the current record
-        if assistant_emails.empty?
-          original_assistant_value = nil
-          new_employee[3] = old_employee&.fetch(3) 
-        else
-          original_assistant_value = new_employee[3]
-        end
-
-        if old_employee.nil?
-          add_transform(:insert, new_employee)
-        elsif new_employee[0, 4] == old_employee[0, 4]
-          # restore assistant value after cleanup like missing assistants and own email
-          new_employee[3] = original_assistant_value
-          add_transform(:noop, new_employee) unless options[:skip_noop]
-        else
-          add_transform(:update, new_employee)
-        end
-      end
-    end
-
-    def add_transform(op, employee)
-      return if employee.nil?
-      email = employee[1]
-      existing_operation = transforms_index[email]
-      if existing_operation.nil?
-        operation = [op, *employee]
-        transforms_index[email] = operation
-        transforms << operation
-      end
-    end
-
-    def find_new_employee(email)
-      new_employees[email]
-    end
-
-    def find_current_employee(email)
-      current_employees[email]
-    end
-
-    def new_employees
-      @new_employees ||= build_index(new_directory)
-    end
-
-    def current_employees
-      @current_employees ||= build_index(current_directory)
-    end
-
-    def unseen_employees
-      emails = current_employees.keys - new_employees.keys
-      emails.map do |email|
-        [email, current_employees[email]]
-      end
-    end
-
-    def build_index(directory)
-      accum = {}
-      directory.each do |employee|
-        # Item at index 1 is email, so downcase it
-        employee[1] = employee[1].downcase unless employee[1].nil?
-        email = employee[1]
-        accum[email] = employee
-      end
-
-      accum
+    def into(new_directory, options = {})
+      Transformer::InMemory.new(current_directory).into(new_directory, options)
     end
   end
 end

--- a/lib/directory_diff/transformer/in_memory.rb
+++ b/lib/directory_diff/transformer/in_memory.rb
@@ -1,0 +1,126 @@
+module DirectoryDiff
+  module Transformer
+    class InMemory 
+      attr_reader :current_directory, :new_directory
+      attr_reader :transforms, :transforms_index
+      attr_reader :options
+
+      def initialize(current_directory)
+        @current_directory = current_directory
+        @transforms = []
+        @transforms_index = {}
+      end
+
+      def into(new_directory, options={})
+        raise ArgumentError unless new_directory.respond_to?(:each)
+        @new_directory = new_directory
+        @options = options || {}
+
+        new_employees.each do |email, employee|
+          process_employee(email, employee)
+        end
+
+        unseen_employees.each do |email, employee|
+          process_employee(email, employee)
+        end
+
+        transforms
+      end
+
+      protected
+
+      def process_employee(email, assistant_owner)
+        new_employee = find_new_employee(email)
+        old_employee = find_current_employee(email)
+
+        # cycle detection
+        if transforms_index.has_key?(email)
+          return
+        end
+        transforms_index[email] = nil
+
+        if new_employee.nil?
+          add_transform(:delete, old_employee)
+          assistants_string = assistant_owner[3].to_s.split(",").reject do |assistant|
+                                assistant == email
+                              end.join(",")
+          assistant_owner[3] = assistants_string == "" ? nil : assistants_string
+        else
+          own_email = new_employee[1]
+          assistant_emails = new_employee[3].to_s.split(",")
+          assistant_emails.delete(own_email)
+
+          assistant_emails.each do |assistant_email|
+            process_employee(assistant_email, new_employee)
+          end
+
+          # assistant_emails may be nil. we only use the csv to *set*
+          # assistants. if it was nil, we backfill from current employee so that
+          # the new record appears to be the same as the current record
+          if assistant_emails.empty?
+            original_assistant_value = nil
+            new_employee[3] = old_employee&.fetch(3) 
+          else
+            original_assistant_value = new_employee[3]
+          end
+
+          if old_employee.nil?
+            add_transform(:insert, new_employee)
+          elsif new_employee[0, 4] == old_employee[0, 4]
+            # restore assistant value after cleanup like missing assistants and own email
+            new_employee[3] = original_assistant_value
+            add_transform(:noop, new_employee) unless options[:skip_noop]
+          else
+            add_transform(:update, new_employee)
+          end
+        end
+      end
+
+      def add_transform(op, employee)
+        return if employee.nil?
+        email = employee[1]
+        existing_operation = transforms_index[email]
+        if existing_operation.nil?
+          operation = [op, *employee]
+          transforms_index[email] = operation
+          transforms << operation
+        end
+      end
+
+      def find_new_employee(email)
+        new_employees[email]
+      end
+
+      def find_current_employee(email)
+        current_employees[email]
+      end
+
+      def new_employees
+        @new_employees ||= build_index(new_directory)
+      end
+
+      def current_employees
+        @current_employees ||= build_index(current_directory)
+      end
+
+      def unseen_employees
+        emails = current_employees.keys - new_employees.keys
+        emails.map do |email|
+          [email, current_employees[email]]
+        end
+      end
+
+      def build_index(directory)
+        accum = {}
+        directory.each do |employee|
+          # Item at index 1 is email, so downcase it
+          employee[1] = employee[1].downcase unless employee[1].nil?
+          email = employee[1]
+          accum[email] = employee
+        end
+
+        accum
+      end
+    end
+  end
+end

--- a/lib/directory_diff/transformer/temp_table.rb
+++ b/lib/directory_diff/transformer/temp_table.rb
@@ -1,0 +1,238 @@
+require "activerecord_pg_stuff"
+
+Arel::Predications.module_eval do
+  def contains(other)
+    Arel::Nodes::InfixOperation.new(:"@>", self, other)
+  end
+end
+
+module DirectoryDiff
+  module Transformer
+    class TempTable
+      attr_reader :current_directory, :operations
+
+      # @params current_directory a relation that filters out only the records
+      #                           that represent the current directory. This is
+      #                           mostly likely an Employee relation. This
+      #                           relation will be pulled into a temporary table.
+      def initialize(current_directory)
+        @current_directory = current_directory
+        @operations = []
+      end
+
+      # @param new_directory a table containing only the new records to compare
+      #                      against, most likely a temp table.
+      def into(new_directory, options = {})
+        projection = <<-SQL
+          name, 
+          lower(email) email, 
+          coalesce(phone_number, '') phone_number,
+          array_remove(
+            regexp_split_to_array(
+              coalesce(assistants, ''),
+              '\s*,\s*'
+            )::varchar[],
+            ''
+          ) assistants
+        SQL
+        current_directory.select(projection).temporary_table do |temp_current_directory|
+          # Remove dupe email rows, keeping the last one
+          latest_unique_sql = <<-SQL
+            SELECT 
+              DISTINCT ON (lower(email)) name, 
+              lower(email) email,
+              coalesce(phone_number, '') phone_number,
+              array_remove(
+                regexp_split_to_array(
+                  coalesce(assistants, ''),
+                  '\s*,\s*'
+                )::varchar[],
+                ''
+              ) assistants, 
+              extra, 
+              ROW_NUMBER () OVER ()
+            FROM 
+              #{new_directory.arel_table.name} 
+            ORDER BY 
+              lower(email), 
+              row_number desc
+          SQL
+
+          new_directory.select('*')
+            .from(Arel.sql("(#{latest_unique_sql}) as t"))
+            .order("row_number").temporary_table do |deduped_csv|
+            # Get Arel tables for referencing fields, table names
+            employees = temp_current_directory.table
+            csv = deduped_csv.table
+
+            # Reusable Arel predicates
+            csv_employee_join = csv[:email].eq(employees[:email])
+            attributes_unchanged = employees[:name].eq(csv[:name])
+                                    .and(employees[:phone_number].eq(csv[:phone_number]))
+                                    .and(employees[:assistants].contains(csv[:assistants]))
+
+            # Creates joins between the temp table and the csv table and
+            # vice versa
+            # Cribbed from https://gist.github.com/mildmojo/3724189
+            csv_to_employees = csv.join(employees, Arel::Nodes::OuterJoin)
+                                .on(csv_employee_join)
+                                .join_sources
+            employees_to_csv = employees.join(csv, Arel::Nodes::OuterJoin)
+                                .on(csv_employee_join)
+                                .join_sources
+
+            # Representation of the joined csv-employees, with csv on the left
+            csv_records = deduped_csv.joins(csv_to_employees).order('row_number asc')
+            # Representation of the joined employees-csv, with employees on the
+            # left
+            employee_records = temp_current_directory.joins(employees_to_csv)
+
+            # Cleanup some bad records
+            # 1. Assistant email is set on an employee, but no assistant record
+            #    in csv. Remove the assistant email.
+            # 2. Assistant email is employee's own email. Remove the assistant
+            #    email.
+            # TODO move this into the temp table creation above
+            # https://www.db-fiddle.com/f/gxg6qABP1LygYvvgRvyH2N/1
+            cleanup_sql = <<-SQL
+              with
+                unnested_assistants as
+                (
+                  select
+                    email,
+                    name,
+                    case
+                      when array_length(assistants, 1) is null then null
+                      else unnest(assistants)
+                    end as assistant
+                  from #{csv.name} 
+                ),
+                own_email_removed as
+                (
+                  select
+                    a.*
+                  from unnested_assistants a
+                  where
+                    a.email != a.assistant
+                    or a.assistant is null
+                ),
+                missing_assistants_removed as
+                (
+                  select
+                    a.*
+                  from own_email_removed a
+                  left outer join #{csv.name} b on a.assistant = b.email
+                  where
+                    (a.assistant is null and b.email is null)
+                    or (a.assistant is not null and b.email is not null)
+                ),
+                only_valid_assistants as
+                (
+                  select
+                    a.email, 
+                    a.name,
+                    array_remove(
+                      array_agg(b.assistant),
+                      null
+                    ) assistants
+                  from #{csv.name} a
+                  left outer join missing_assistants_removed b
+                  using (email)
+                  group by
+                    a.email, a.name
+                )
+              update #{csv.name}
+              set assistants = only_valid_assistants.assistants
+              from only_valid_assistants
+              where #{csv.name}.email = only_valid_assistants.email
+            SQL
+            deduped_csv.connection.execute(cleanup_sql)
+
+            # new records are records in the new directory that don't exist in
+            # the current directory
+            new_records = csv_records.select("'insert'::varchar operation, row_number")
+                            .select(:name, :email, :phone_number, :assistants, :extra)
+                            .where({ employees.name => { email: nil } })
+            # deleted records are records in the current directory that don't
+            # exist in the new directory
+            deleted_records = employee_records.select("'delete'::varchar operation, row_number")
+                                .select(:name, :email, :phone_number, :assistants, :extra)
+                                .where({ csv.name => { email: nil } })
+            # changed records are records that have difference in name, phone
+            # number and/or assistants
+            changed_records = csv_records.select("'update'::varchar operation, row_number")
+                                .select(:name, :email, :phone_number, :assistants, :extra)
+                                .where.not(attributes_unchanged)
+            # unchanged records are records that are exactly the same in both
+            # directories (without considering the extra field)
+            unchanged_records = csv_records.select("'noop'::varchar operation, row_number")
+                                  .select(:name, :email, :phone_number, :assistants, :extra)
+                                  .where(attributes_unchanged)
+
+            # create temp table for holding operations
+            operations_temp_table = "temporary_operations_#{self.object_id}"
+            deduped_csv.connection.with_temporary_table operations_temp_table, new_records.to_sql do |name|
+              dec = ActiveRecordPgStuff::Relation::TemporaryTable::Decorator.new csv_records.klass, name
+              rel = ActiveRecord::Relation.new dec, table: dec.arel_table
+              rel.readonly!
+
+              rel.connection.execute("insert into #{name}(operation, row_number, name, email, phone_number, assistants, extra) #{deleted_records.to_sql}")
+              rel.connection.execute("insert into #{name}(operation, row_number, name, email, phone_number, assistants, extra) #{changed_records.to_sql}")
+
+              if options[:skip_noop] != true
+                rel.connection.execute("insert into #{name}(operation, row_number, name, email, phone_number, assistants, extra) #{unchanged_records.to_sql}")
+              end
+
+              rel.order(:row_number).each do |operation|
+                add_operation(operation)
+              end
+            end
+          end
+        end
+
+        prioritize_assistants(operations)
+      end
+
+      private
+
+      def add_operation(operation)
+        op = [
+          operation.operation.to_sym,
+          operation.name,
+          operation.email,
+          operation.phone_number.presence,
+          serialize_pg_array(operation.assistants)
+        ]
+        op << operation.extra unless operation[:extra].nil?
+        operations << op
+      end
+
+      def serialize_pg_array(pg_array)
+        return if pg_array.nil?
+        pg_array = pg_array[1...-1] # remove the curly braces
+        pg_array.presence
+      end
+
+      def prioritize_assistants(operations)
+        prioritized_operations = []
+        operations.each do |operation|
+          process_operation(operation, operations, prioritized_operations, Set.new)
+        end
+        prioritized_operations
+      end
+
+      def process_operation(operation, operations, prioritized_operations, tail)
+        (_, _, email, _, assistants) = operation
+        return if prioritized_operations.find { |_, _, e| e == email }
+
+        (assistants || '').split(',').each do |assistant_email|
+          next if tail.include?(assistant_email)
+          assistant_operation = operations.find { |_, _, email| email == assistant_email }
+          process_operation(assistant_operation, operations, prioritized_operations, tail.add(email))
+        end
+
+        prioritized_operations << operation
+      end
+    end
+  end
+end

--- a/lib/directory_diff/transformer/temp_table.rb
+++ b/lib/directory_diff/transformer/temp_table.rb
@@ -101,10 +101,7 @@ module DirectoryDiff
                   select
                     email,
                     name,
-                    case
-                      when array_length(assistants, 1) is null then null
-                      else unnest(assistants)
-                    end as assistant
+                    unnest(assistants) assistant
                   from #{csv.name} 
                 ),
                 own_email_removed as
@@ -112,9 +109,7 @@ module DirectoryDiff
                   select
                     a.*
                   from unnested_assistants a
-                  where
-                    a.email != a.assistant
-                    or a.assistant is null
+                  where a.email != a.assistant
                 ),
                 missing_assistants_removed as
                 (

--- a/spec/directory_diff/transformer/in_memory_spec.rb
+++ b/spec/directory_diff/transformer/in_memory_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe DirectoryDiff::Transform do
+describe DirectoryDiff::Transformer::InMemory do
   it_behaves_like "a directory transformer" do
     let(:source_directory) { current_directory }
     let(:target_directory) { new_directory }

--- a/spec/directory_diff/transformer/in_memory_spec.rb
+++ b/spec/directory_diff/transformer/in_memory_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe DirectoryDiff::Transformer::InMemory do
-  it_behaves_like "a directory transformer" do
+  it_behaves_like "a directory transformer", :in_memory do
     let(:source_directory) { current_directory }
     let(:target_directory) { new_directory }
   end

--- a/spec/directory_diff/transformer/temp_table_spec.rb
+++ b/spec/directory_diff/transformer/temp_table_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+
+describe DirectoryDiff::Transformer::TempTable do
+  it_behaves_like "a directory transformer", :temp_table do
+    let(:source_directory) { current_directory_relation }
+    let(:target_directory) { new_directory_relation }
+  end
+
+  let(:table) do
+    Temping.create :directory do
+      with_columns do |t|
+        t.string :name
+        t.string :email
+        t.string :phone_number
+        t.string :assistants
+      end
+    end
+  end
+
+  let(:csv_table) do
+    Temping.create :csv_table do
+      with_columns do |t|
+        t.string :name
+        t.string :email
+        t.string :phone_number
+        t.string :assistants
+        t.string :extra
+      end
+    end
+  end
+
+  let(:current_directory_relation) do
+    current_directory.each do |name, email, phone_number, assistants|
+      table.create({
+        name: name,
+        email: email,
+        phone_number: phone_number,
+        assistants: assistants
+      })
+    end
+    table.all
+  end
+
+  let(:new_directory_relation) do
+    new_directory.each do |name, email, phone_number, assistants, extra|
+      csv_table.create({
+        name: name,
+        email: email,
+        phone_number: phone_number,
+        assistants: assistants,
+        extra: extra
+      })
+    end
+    csv_table.all
+  end
+end

--- a/spec/support/database.yml
+++ b/spec/support/database.yml
@@ -1,0 +1,4 @@
+host: "localhost"
+adapter: "postgresql"
+encoding: utf-8
+database: "test"

--- a/spec/support/shared_examples/transform.rb
+++ b/spec/support/shared_examples/transform.rb
@@ -1,7 +1,8 @@
-shared_examples "a directory transformer" do
+shared_examples "a directory transformer" do |processor|
   describe '#into' do
     subject do
-      DirectoryDiff.transform(source_directory).into(target_directory, options)
+      DirectoryDiff.transform(source_directory)
+        .into(target_directory, options.merge(processor: processor))
     end
     let(:options) { {} }
 

--- a/spec/support/temping.rb
+++ b/spec/support/temping.rb
@@ -1,0 +1,13 @@
+require "temping"
+
+RSpec.configure do |config|
+  config.before :suite do
+    yaml = File.join(File.dirname(__FILE__), "database.yml")
+    db_config = YAML::load(File.open(yaml))
+    ActiveRecord::Base.establish_connection(db_config)
+  end
+
+  config.after do
+    Temping.teardown
+  end
+end

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/.gitignore
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/.gitignore
@@ -1,0 +1,17 @@
+*.gem
+*.rbc
+.bundle
+.config
+.yardoc
+Gemfile.lock
+InstalledFiles
+_yardoc
+coverage
+doc/
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/.rspec
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/.rspec
@@ -1,0 +1,3 @@
+--color
+-fd
+--order=rand

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/.travis.yml
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/.travis.yml
@@ -1,0 +1,9 @@
+rvm:
+- 1.9.3
+- 2.0.0
+
+env:
+  global:
+    - DATABASE_URL=postgresql://postgres@localhost
+
+script: bundle exec rake

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/Gemfile
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in activerecord_pg_stuff.gemspec
+gemspec

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/LICENSE.txt
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2013 Dmitry Galinsky
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/README.md
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/README.md
@@ -1,0 +1,72 @@
+# ActiveRecordPgStuff
+
+Adds support for working with temporary tables and pivot tables (PostgreSQL only).
+
+* [![Build Status](https://travis-ci.org/dima-exe/activerecord_pg_stuff.png?branch=master)](https://travis-ci.org/dima-exe/activerecord_pg_stuff)
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+    gem 'activerecord_pg_stuff'
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install activerecord_pg_stuff
+
+## Usage
+
+#### Temporary tables
+
+Example:
+
+    User.select(:id, :email).temporary_table do |rel|
+      rel.pluck(:id)
+    end
+
+#### Pivot tables
+
+Before using, you need to create the extension:
+
+    CREATE EXTENSION tablefunc
+
+Example:
+
+    CREATE TABLE payments (id integer, amount integer, seller_id integer, created_at timestamp)
+    INSERT INTO payments
+      VALUES (1, 1,  1, '2012-10-12 10:00 UTC'),
+             (2, 3,  1, '2012-11-12 10:00 UTC'),
+             (3, 5,  2, '2012-09-12 10:00 UTC'),
+             (4, 7,  2, '2012-10-12 10:00 UTC'),
+             (5, 11, 2, '2012-11-12 10:00 UTC'),
+             (6, 13, 2, '2012-11-12 10:00 UTC')
+
+    Payment
+      .select("SUM(amount) AS amount", :seller_id, "DATE_TRUNC('month', created_at) AS month")
+      .group("seller_id, DATE_TRUNC('month', created_at)")
+      .temporary_table do |rel|
+        # :month     - for row
+        # :seller_id - for column
+        # :amount    - for value
+        rel.pivot(:month, :seller_id, :amount)
+    end
+
+    expect(result.headers).to eq [nil, 1, 2]
+
+    expect(result.rows).to eq [
+      [ Time.utc(2012, 9,  1), nil, 5  ],
+      [ Time.utc(2012, 10, 1), 1,   7  ],
+      [ Time.utc(2012, 11, 1), 3,   24 ],
+    ]
+
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/Rakefile
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => [:spec]

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/activerecord_pg_stuff.gemspec
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/activerecord_pg_stuff.gemspec
@@ -1,0 +1,27 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'activerecord_pg_stuff/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = "activerecord_pg_stuff"
+  spec.version       = ActiveRecordPgStuff::VERSION
+  spec.authors       = ["Dmitry Galinsky"]
+  spec.email         = ["dima.exe@gmail.com"]
+  spec.description   = %q{ Adds support for working with temporary tables and pivot tables (PostgreSQL only) }
+  spec.summary       = %q{ Adds support for working with temporary tables and pivot tables (PostgreSQL only) }
+  spec.homepage      = ""
+  spec.license       = "MIT"
+
+  spec.files         = `git ls-files`.split($/)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_runtime_dependency "activerecord", "~> 4.0"
+
+  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "pg"
+end

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/activerecord_pg_stuff.gemspec
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/activerecord_pg_stuff.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", "~> 4.0"
+  spec.add_runtime_dependency "activerecord", ">= 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/lib/activerecord_pg_stuff.rb
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/lib/activerecord_pg_stuff.rb
@@ -1,0 +1,12 @@
+require 'active_record'
+require 'active_record/connection_adapters/postgresql_adapter'
+
+require File.expand_path("../activerecord_pg_stuff/version",                    __FILE__)
+require File.expand_path("../activerecord_pg_stuff/connection/temporary_table", __FILE__)
+require File.expand_path("../activerecord_pg_stuff/relation/temporary_table",   __FILE__)
+require File.expand_path("../activerecord_pg_stuff/relation/pivot",             __FILE__)
+
+ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send :include, ActiveRecordPgStuff::Connection::TemporaryTable
+
+ActiveRecord::Relation.send :include, ActiveRecordPgStuff::Relation::TemporaryTable
+ActiveRecord::Relation.send :include, ActiveRecordPgStuff::Relation::Pivot

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/lib/activerecord_pg_stuff/connection/temporary_table.rb
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/lib/activerecord_pg_stuff/connection/temporary_table.rb
@@ -1,0 +1,22 @@
+module ActiveRecordPgStuff
+  module Connection
+
+    module TemporaryTable
+
+      def with_temporary_table(name, sql, &block)
+        transaction do
+          begin
+            sql = sql.gsub(/\n/, ' ').gsub(/ +/, ' ').strip
+            sql = "CREATE TEMPORARY TABLE #{name} ON COMMIT DROP AS #{sql}"
+            conn.execute sql
+            yield name
+          ensure
+            execute("DROP TABLE IF EXISTS #{name}") rescue nil
+          end
+        end
+      end
+
+    end
+
+  end
+end

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/lib/activerecord_pg_stuff/connection/temporary_table.rb
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/lib/activerecord_pg_stuff/connection/temporary_table.rb
@@ -8,7 +8,7 @@ module ActiveRecordPgStuff
           begin
             sql = sql.gsub(/\n/, ' ').gsub(/ +/, ' ').strip
             sql = "CREATE TEMPORARY TABLE #{name} ON COMMIT DROP AS #{sql}"
-            conn.execute sql
+            execute sql
             yield name
           ensure
             execute("DROP TABLE IF EXISTS #{name}") rescue nil

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/lib/activerecord_pg_stuff/relation/pivot.rb
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/lib/activerecord_pg_stuff/relation/pivot.rb
@@ -1,0 +1,54 @@
+module ActiveRecordPgStuff
+  module Relation
+
+    class PivotResult
+      attr_reader :headers, :rows
+
+      def initialize(header_result, result)
+        @headers = [nil] + result_to_array(header_result).map(&:first)
+        @rows    =  result_to_array(result)
+      end
+
+      def each_row(&block)
+        rows.each(&block)
+      end
+
+      private
+        def result_to_array(result)
+          result.to_hash.map do |h|
+            result.columns.inject([]) do |a, col|
+              a << result.column_types[col].type_cast(h[col])
+            end
+          end
+        end
+    end
+
+    module Pivot
+
+      def pivot(row_id, col_id, val_id)
+
+        types_sql = %{ SELECT column_name, data_type FROM information_schema.columns WHERE table_name = #{connection.quote self.table_name} AND column_name IN (#{connection.quote row_id},#{connection.quote val_id}) }
+        types = connection.select_all types_sql
+        types = types.to_a.map(&:values).inject({}) do |a, v|
+          a[v[0]] = v[1]
+          a
+        end
+        row_type = types[row_id.to_s]
+        val_type = types[val_id.to_s]
+
+        cols = connection.select_all self.except(:select).select("DISTINCT #{col_id}").order(col_id).to_sql
+        cols_list = cols.rows.map(&:first).map do |c|
+          "#{col_id}_#{c} #{val_type}"
+        end.join(", ")
+
+        rel_1 = connection.quote self.select(row_id, col_id, val_id).order(row_id).to_sql
+        rel_2 = connection.quote self.except(:select).select("DISTINCT #{col_id}").order(col_id).to_sql
+        sql = %{ SELECT * FROM crosstab(#{rel_1}, #{rel_2}) AS (row_id #{row_type}, #{cols_list}) }
+        PivotResult.new cols, connection.select_all(sql)
+      end
+
+    end
+
+  end
+end
+

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/lib/activerecord_pg_stuff/relation/temporary_table.rb
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/lib/activerecord_pg_stuff/relation/temporary_table.rb
@@ -1,0 +1,38 @@
+module ActiveRecordPgStuff
+  module Relation
+
+    module TemporaryTable
+
+      class Decorator
+        attr_reader :table_name, :arel_table, :quoted_table_name
+
+        def initialize(object, table_name)
+          @table_name        = table_name
+          @object            = object
+          @arel_table        = Arel::Table.new(table_name)
+          @quoted_table_name = @object.connection.quote_table_name(table_name)
+        end
+
+        def method_missing(name, *args, &block)
+          @object.send(name, *args, &block)
+        end
+
+        def respond_to?(name, *args)
+          @object.respond_to?(name, *args)
+        end
+      end
+
+      def temporary_table
+        tname = "temporary_#{self.table_name}_#{self.object_id}"
+        self.klass.connection.with_temporary_table tname, self.to_sql do |name|
+          dec     = Decorator.new self.klass, name
+          rel     = ActiveRecord::Relation.new dec, dec.arel_table
+          rel.readonly!
+          yield rel
+        end
+      end
+
+    end
+
+  end
+end

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/lib/activerecord_pg_stuff/relation/temporary_table.rb
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/lib/activerecord_pg_stuff/relation/temporary_table.rb
@@ -26,7 +26,7 @@ module ActiveRecordPgStuff
         tname = "temporary_#{self.table_name}_#{self.object_id}"
         self.klass.connection.with_temporary_table tname, self.to_sql do |name|
           dec     = Decorator.new self.klass, name
-          rel     = ActiveRecord::Relation.new dec, dec.arel_table
+          rel     = ActiveRecord::Relation.new dec, table: dec.arel_table
           rel.readonly!
           yield rel
         end

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/lib/activerecord_pg_stuff/version.rb
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/lib/activerecord_pg_stuff/version.rb
@@ -1,0 +1,3 @@
+module ActiveRecordPgStuff
+  VERSION = "0.0.1"
+end

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/spec/lib/connection_temporary_table_spec.rb
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/spec/lib/connection_temporary_table_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe ActiveRecordPgStuff::Connection::TemporaryTable do
+
+  context "with_temporary_table" do
+    let(:sql) { "SELECT * FROM sellers WHERE id IN(1,2)" }
+
+    it "should create temporary table with 'name' and 'sql' and drop it after block executed" do
+      rs = conn.with_temporary_table 'sellers_tmp', sql do |name|
+        conn.select_all("SELECT * FROM #{name}").to_a.map(&:values)
+      end
+      expect(rs).to eq [%w{1 foo}, %w{2 bar}]
+      expect {
+        conn.execute 'SELECT * FROM sellers_tmp'
+      }.to raise_error(ActiveRecord::StatementInvalid, /PG::UndefinedTable/)
+    end
+
+    it "should create nested temporary tables" do
+      rs = conn.with_temporary_table 'sellers_tmp', sql do |name|
+        sql = "SELECT * FROM #{name} WHERE id = 1"
+        conn.with_temporary_table 'sellers_tmp_nested', sql do |name_nested|
+          conn.select_all("SELECT * FROM #{name_nested}").to_a.map(&:values)
+        end
+      end
+      expect(rs).to eq [%w{1 foo}]
+      expect {
+        conn.execute 'SELECT * FROM sellers_tmp'
+      }.to raise_error(ActiveRecord::StatementInvalid, /PG::UndefinedTable/)
+      expect {
+        conn.execute 'SELECT * FROM sellers_tmp_nested'
+      }.to raise_error(ActiveRecord::StatementInvalid, /PG::UndefinedTable/)
+    end
+
+  end
+end

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/spec/lib/relation_pivot_spec.rb
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/spec/lib/relation_pivot_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe ActiveRecordPgStuff::Relation::TemporaryTable do
+
+  context "pivot" do
+
+    let(:rel) { Payment }
+
+    it "should create pivot table from relation" do
+      rs = rel.select(:seller_id, "SUM(amount) AS amount", "DATE_TRUNC('month', created_at) AS created_at")
+              .group("seller_id, DATE_TRUNC('month', created_at)").temporary_table do |tmp|
+                tmp.pivot :created_at, :seller_id, :amount
+              end
+
+      expect(rs.headers).to eq [nil,1,2]
+      expect(rs.rows).to eq [
+        [ Time.utc(2012, 9,  1), nil, 5  ],
+        [ Time.utc(2012, 10, 1), 1,   7  ],
+        [ Time.utc(2012, 11, 1), 3,   24 ],
+      ]
+    end
+
+  end
+
+end

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/spec/lib/relation_temporary_table_spec.rb
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/spec/lib/relation_temporary_table_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe ActiveRecordPgStuff::Relation::TemporaryTable do
+
+  context "temporary_table" do
+
+    let(:rel) { Seller.where(id: [1,2]) }
+
+    it "should create temporary table from relation" do
+      rs = rel.temporary_table do |tmp|
+        tmp.where(id: [1,2]).load
+      end
+      expect(rs.map(&:class)).to eq [Seller, Seller]
+      expect(rs.map(&:class).map(&:table_name)).to eq %w{ sellers sellers }
+      expect(rs.map(&:id)).to eq [1,2]
+      expect(rs.map(&:readonly?)).to eq [true, true]
+    end
+
+    it "should create nested temporary tables from relation" do
+      rs = rel.select("id * 10 AS id").temporary_table do |tmp|
+        tmp.where(id: [10]).temporary_table do |nested_tmp|
+          nested_tmp.where(id: [10,20]).load
+        end
+      end
+      expect(rs.map(&:id)).to eq [10]
+    end
+
+  end
+
+end

--- a/vendor/gems/activerecord_pg_stuff-0.0.1/spec/spec_helper.rb
+++ b/vendor/gems/activerecord_pg_stuff-0.0.1/spec/spec_helper.rb
@@ -1,0 +1,42 @@
+Bundler.require(:test)
+require 'rspec/autorun'
+require 'logger'
+require File.expand_path("../../lib/activerecord_pg_stuff", __FILE__)
+
+ActiveRecord::Base.logger = Logger.new(STDOUT)
+
+RSpec.configure do |c|
+  c.before(:suite) do
+    ActiveRecord::Base.establish_connection
+  end
+
+  c.before(:all) do
+    conn.execute 'CREATE EXTENSION IF NOT EXISTS tablefunc'
+    conn.execute "CREATE TABLE sellers (id integer, name varchar)"
+    conn.execute "INSERT INTO sellers VALUES(1, 'foo'), (2, 'bar'), (3, 'baz')"
+
+    conn.execute "CREATE TABLE payments (id integer, amount integer, seller_id integer, created_at timestamp)"
+    conn.execute "INSERT INTO payments VALUES(1, 1,  1, '2012-10-12 10:00 UTC')"
+    conn.execute "INSERT INTO payments VALUES(2, 3,  1, '2012-11-12 10:00 UTC')"
+    conn.execute "INSERT INTO payments VALUES(3, 5,  2, '2012-09-12 10:00 UTC')"
+    conn.execute "INSERT INTO payments VALUES(4, 7,  2, '2012-10-12 10:00 UTC')"
+    conn.execute "INSERT INTO payments VALUES(5, 11, 2, '2012-11-12 10:00 UTC')"
+    conn.execute "INSERT INTO payments VALUES(6, 13, 2, '2012-11-12 10:00 UTC')"
+  end
+
+  c.after(:all) do
+    conn.execute("DROP TABLE sellers")
+    conn.execute("DROP TABLE payments")
+  end
+end
+
+def conn
+  ActiveRecord::Base.connection
+end
+
+class Seller < ActiveRecord::Base
+end
+
+class Payment < ActiveRecord::Base
+end
+


### PR DESCRIPTION
Currently, directory diffing works by loading both directories in memory and performing a line-by-line comparison. For small directories, this works well, but we risk running out of memory for very large directories.

This PR adds an option to perform the diffing using SQL. This works by loading the current directory and the incoming csv as temp tables and performing a few queries in order to identify new records, deleted records and changed records.

~~One big difference in the implementation with the in memory version is we bunch up all the `inserts` first, then `deletes`, followed by `updates` and `noop`. The idea is that any record inside these blocks of operations don't really have strict ordering between the rows. In the in-memory implementation, we traverse the records depth-first, so that dependent assistant records are processed before their owners. To smooth over these differences, I introduced an `Operations` class that overrides `==` so that specs pass in either version.~~

Another difference is the expected input for the temp table mode. The in-memory mode expects an array of arrays of the form `[name, email, phone_number, assistants]`. The temp table expects an `ActiveRecord` relation for both the current and CSV. For the CSV, we can use something like https://github.com/mynameisrufus/theman to load into a table.