### PR TITLE
Add support for non-relation new directory

### DIFF
--- a/spec/directory_diff/transformer/temp_table_array_target_spec.rb
+++ b/spec/directory_diff/transformer/temp_table_array_target_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+describe DirectoryDiff::Transformer::TempTable, "target directory coming in as array" do
+  it_behaves_like "a directory transformer", :temp_table do
+    let(:source_directory) { current_directory_relation }
+    let(:target_directory) { new_directory }
+  end
+
+  let(:table) do
+    Temping.create :directory do
+      with_columns do |t|
+        t.string :name
+        t.string :email
+        t.string :phone_number
+        t.string :assistants
+      end
+    end
+  end
+
+  let(:current_directory_relation) do
+    current_directory.each do |name, email, phone_number, assistants|
+      table.create({
+        name: name,
+        email: email,
+        phone_number: phone_number,
+        assistants: assistants
+      })
+    end
+    table.all
+  end
+end


### PR DESCRIPTION
In envoy-web, `DirectoryDiff` is used to compare the current directory and the new directory. We will be able to supply DirectoryDiff with a relation version of current directory but not always a relation version of new directory. This is because the initial assumption was that new directory will always be a CSV file (initial thoughts was to use postgres `copy` to slurp the file into a temp table).

While integrating this library, I noticed that we use this library for Google sync, Okta API sync, OneLogin API sync.

This PR keeps all of the previous logic, but adds a step to create a temp table and bulk inserting the array before handing over the relation.