### PR TITLE
Treat nil phone numbers as noop

### DIFF
--- a/lib/directory_diff/transformer/in_memory.rb
+++ b/lib/directory_diff/transformer/in_memory.rb
@@ -64,11 +64,24 @@ module DirectoryDiff
             original_assistant_value = new_employee[3]
           end
 
+          # phone_number may be nil. we only use the csv to *set* phone numbers if
+          # it has a value. if it was nil, we backfill from current employee so that
+          # the new record apperas to the be same as the current record
+          phone_number = new_employee[2].presence
+          if phone_number.nil?
+            original_phone_number_value = nil
+            new_employee[2] = old_employee&.fetch(2)
+          else
+            original_phone_number_value = new_employee[2]
+          end
+
           if old_employee.nil?
             add_transform(:insert, new_employee)
           elsif new_employee[0, 4] == old_employee[0, 4]
             # restore assistant value after cleanup like missing assistants and own email
             new_employee[3] = original_assistant_value
+            # restore phone number value
+            new_employee[2] = original_phone_number_value
             add_transform(:noop, new_employee) unless options[:skip_noop]
           else
             add_transform(:update, new_employee)

--- a/lib/directory_diff/transformer/temp_table.rb
+++ b/lib/directory_diff/transformer/temp_table.rb
@@ -173,7 +173,12 @@ module DirectoryDiff
           if activerecord52?
             rel = ActiveRecord::Relation.new(dec)
           else
-            rel = ActiveRecord::Relation.new(dec, dec.arel_table, dec.predicate_builder, {})
+            rel = ActiveRecord::Relation.new(
+              dec,
+              dec.arel_table,
+              dec.predicate_builder,
+              {}
+            )
           end
           rel.readonly!
           block.call(rel)

--- a/lib/directory_diff/transformer/temp_table.rb
+++ b/lib/directory_diff/transformer/temp_table.rb
@@ -36,6 +36,10 @@ module DirectoryDiff
             attributes_unchanged = employees[:name].eq(csv[:name])
                                     .and(
                                       employees[:phone_number].eq(csv[:phone_number])
+                                        .or(csv[:phone_number].eq(""))
+                                        # ☝🏽 Comparing to an empty string because we cast
+                                        # phone number to an empty string. The reason is
+                                        # comparing NULL = NULL is always false in SQL
                                     )
                                     .and(
                                       employees[:assistants].contains(csv[:assistants])

--- a/spec/support/shared_examples/transform.rb
+++ b/spec/support/shared_examples/transform.rb
@@ -170,12 +170,12 @@ shared_examples "a directory transformer" do |processor|
         end
       end
 
-      context "when the phone number field comes in as nil" do
+      context "when the phone number field comes in as nil or empty string" do
         let(:new_directory) do
           [
             ['Kamal Mahyuddin', 'kamal@envoy.com', nil, nil],
             ['Adolfo Builes', 'adolfo@envoy.com', nil, nil],
-            ['Matthew Johnston', 'matthew@envoy.com', nil, nil]
+            ['Matthew Johnston', 'matthew@envoy.com', '', nil]
           ]
         end
 

--- a/spec/support/shared_examples/transform.rb
+++ b/spec/support/shared_examples/transform.rb
@@ -170,6 +170,24 @@ shared_examples "a directory transformer" do |processor|
         end
       end
 
+      context "when the phone number field comes in as nil" do
+        let(:new_directory) do
+          [
+            ['Kamal Mahyuddin', 'kamal@envoy.com', nil, nil],
+            ['Adolfo Builes', 'adolfo@envoy.com', nil, nil],
+            ['Matthew Johnston', 'matthew@envoy.com', nil, nil]
+          ]
+        end
+
+        it "returns a noop, because nil phone number does not overwrite" do
+          expect(subject).to eq([
+            [:noop, 'Kamal Mahyuddin', 'kamal@envoy.com', nil, nil],
+            [:noop, 'Adolfo Builes', 'adolfo@envoy.com', nil, nil],
+            [:noop, 'Matthew Johnston', 'matthew@envoy.com', nil, nil]
+          ])
+        end
+      end
+
       context "in both name and phone number fields" do
         let(:new_directory) do
           [


### PR DESCRIPTION
If the CSV has phone numbers coming in as `nil`, we should treat it as a noop so that it doesn't overwrite the employee's phone number which may have been set via the UI.