### PR TITLE
Emit a noop when assistant field changes

### DIFF
--- a/lib/directory_diff/transformer/temp_table.rb
+++ b/lib/directory_diff/transformer/temp_table.rb
@@ -2,12 +2,6 @@
 
 require "activerecord_pg_stuff"
 
-Arel::Predications.module_eval do
-  def contains(other)
-    Arel::Nodes::InfixOperation.new(:"@>", self, other)
-  end
-end
-
 module DirectoryDiff
   module Transformer
     class TempTable
@@ -38,7 +32,8 @@ module DirectoryDiff
                                       employees[:phone_number].eq(csv[:phone_number])
                                     )
                                     .and(
-                                      employees[:assistants].contains(csv[:assistants])
+                                      employees[:assistants].eq(csv[:assistants])
+                                        .or(csv[:assistants].eq("{}"))
                                     )
 
             # Creates joins between the temp table and the csv table and

--- a/spec/support/shared_examples/transform.rb
+++ b/spec/support/shared_examples/transform.rb
@@ -813,7 +813,7 @@ shared_examples "a directory transformer" do |processor|
             ] 
           end
 
-          it 'returns noop for kamal, assistants' do
+          it 'returns update for kamal, noop for assistants' do
             expect(subject).to eq([
               [:noop, 'Adolfo Builes', 'adolfo@envoy.com', '415-935-3143', nil],
               [:update, 'Kamal Mahyuddin', 'kamal@envoy.com', '415-935-3143', 'adolfo@envoy.com'],

--- a/spec/support/shared_examples/transform.rb
+++ b/spec/support/shared_examples/transform.rb
@@ -803,6 +803,24 @@ shared_examples "a directory transformer" do |processor|
             ])
           end
         end
+
+        context 'new directory sets a subset of assistant emails in last column' do
+          let(:new_directory) do
+            [
+              ['Kamal Mahyuddin', 'kamal@envoy.com', '415-935-3143', 'adolfo@envoy.com'],
+              ['Adolfo Builes', 'adolfo@envoy.com', '415-935-3143', nil],
+              ['Matthew Johnston', 'matthew@envoy.com', '415-441-3232', nil]
+            ] 
+          end
+
+          it 'returns noop for kamal, assistants' do
+            expect(subject).to eq([
+              [:noop, 'Adolfo Builes', 'adolfo@envoy.com', '415-935-3143', nil],
+              [:update, 'Kamal Mahyuddin', 'kamal@envoy.com', '415-935-3143', 'adolfo@envoy.com'],
+              [:noop, 'Matthew Johnston', 'matthew@envoy.com', '415-441-3232', nil],
+            ])
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/161063107

This change treats a change in assistants as an update even if it's a subset of assistants the employee already has in the directory.