### PR TITLE
Bump bundler to 2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: Run CI
+on: [push]
+
+jobs:
+  run-rspec-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: Run tests
+        run: |
+          bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
 gemfile:
   - gemfiles/activerecord_5.1.gemfile
   - gemfiles/activerecord_5.2.gemfile
-before_install: gem install bundler -v 1.11.2
+before_install: gem install bundler -v 2.4.22
 script:
   - bundle exec rake db:create
   - bundle exec rake spec

--- a/directory_diff.gemspec
+++ b/directory_diff.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 5.1"
   spec.add_dependency "pg", "~> 1.1.3"
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "temping", "~> 3.10.0"


### PR DESCRIPTION
Also adds a CI action.

Travis can probably be removed -- will do in a follow-up.